### PR TITLE
Fixes a bug where apps.py was using deprecated ugettext_lazy

### DIFF
--- a/wagtail_draftail_anchors/apps.py
+++ b/wagtail_draftail_anchors/apps.py
@@ -1,6 +1,6 @@
 from django.apps import AppConfig
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class WagtailDraftailAnchorsAppConfig(AppConfig):


### PR DESCRIPTION
This pull request will use the new Django 4 method of translation. This will likely require a version bump or polyfill since it was a breaking change in Django 4. 

Relevant Docs:
Deprecation Notice: https://docs.djangoproject.com/en/4.0/internals/deprecation/
Translation in Django 4: https://docs.djangoproject.com/en/4.0/topics/i18n/translation/