### PR TITLE
Update docs about package order in INSTALLED_APPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ Install using `pip`:
 pip install wagtail-draftail-anchors
 ```
 
-Add `'wagtail_draftail_anchors'` to `INSTALLED_APPS` below `wagtail.admin`.
+Add `'wagtail_draftail_anchors'` to `INSTALLED_APPS` before `wagtail.admin`.
 
 Add `'anchor-identifier'` to the features of any rich text field where you have overridden the default feature list.


### PR DESCRIPTION
I was having an issue with anchor links being treated as regular links after saving a page. It turns out that the error was coming from the order of apps in `INSTALLED_APPS`.

The docs say that we need to place this app `below` 'wagtail.admin'. However, it should be placed `above` it.