### PR TITLE
Fix anchor not working on headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,8 @@ pip install wagtail-draftail-anchors
 
 Add `'wagtail_draftail_anchors'` to `INSTALLED_APPS` below `wagtail.admin`.
 
-Add `'anchor-identifier'` to the features of any rich text field where you have overridden the default feature list.
+Add `'anchor-identifier'` to the features of any rich text field where you have overridden the default feature list. The feature must be added before any heading('h1',...,'h6') feature:
+
+```
+body = RichTextField(features=['anchor-identifier', 'h2', 'h3', 'bold', 'italic', 'link'])
+```

--- a/wagtail_draftail_anchors/wagtail_hooks.py
+++ b/wagtail_draftail_anchors/wagtail_hooks.py
@@ -25,7 +25,7 @@ def register_icons(icons):
 
 @hooks.register("register_rich_text_features")
 def register_rich_text_anchor_identifier_feature(features):
-    features.default_features.append("anchor-identifier")
+    features.default_features.insert(0, "anchor-identifier")
     """
     Registering the `anchor-identifier` feature, which uses the `ANCHOR-IDENTIFIER` Draft.js entity type,
     and is stored as HTML with a `<a data-anchor href="#my-anchor" id="my-anchor">` tag.


### PR DESCRIPTION
Anchors don't work on headings when this app is registered after `wagtail.admin` using Wagtail 3.

This PR fixes it by adding the `anchor-identifier` feature before any headings feature.