### PR TITLE
Add support for custom rendering of anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,35 @@ Add `'anchor-identifier'` to the features of any rich text field where you have 
 ```
 body = RichTextField(features=['anchor-identifier', 'h2', 'h3', 'bold', 'italic', 'link'])
 ```
+
+## Configuration
+
+### Rendered representation of anchors
+
+By default, `anchor-identifier` rich text entities will be rendered as HTML `anchor` elements, e.g.:
+
+``` html
+<a href="#my-element" id="my-element" data-id="my-element">My element</a>
+```
+
+This package provides an alternative renderer that renders `anchor-identifier` entities as HTML `span` elements, e.g.:
+
+``` html
+<span id="my-element">My element</span>
+```
+
+The desired renderer can be specified using the `DRAFTAIL_ANCHORS_RENDERER` setting. To use the `span` renderer, configure your application as follows:
+
+``` python
+DRAFTAIL_ANCHORS_RENDERER = "wagtail_draftail_anchors.rich_text.render_span"
+```
+
+It is possible to define your own renderer. It should be a callable that takes a `dict` of attributes, and returns a string containing the opening tag of the HTML element that represents the anchor target. The `dict` passed to the renderer, for an anchor with an identifier of `"my-anchor"`, would look like the following:
+
+``` python
+{"data-id": "my-anchor", "href": "#my-anchor", "id": "my-anchor", "linktype": "my-anchor"}
+```
+
+If you define your own renderer, you should set the value of `DRAFTAIL_ANCHORS_RENDERER` to your custom renderer's import path.
+
+See `render_span` and `render_a` in `wagtail_draftail_anchors.rich_text` for examples.

--- a/wagtail_draftail_anchors/rich_text.py
+++ b/wagtail_draftail_anchors/rich_text.py
@@ -1,7 +1,6 @@
-import importlib
-
 from django.conf import settings
-from django.utils.html import escape
+from django.utils.html import format_html
+from django.utils.module_loading import import_string
 from draftjs_exporter.dom import DOM
 
 from wagtail import VERSION as wagtail_version
@@ -23,12 +22,11 @@ ANCHOR_TARGET_IDENTIFIER = "anchor-target"
 
 
 def render_span(attrs):
-    return '<span id="%s">' % escape(attrs["id"])
+    return format_html('<span id="{}">', attrs["id"])
 
 
 def render_a(attrs):
-    id_ = escape(attrs["id"])
-    return '<a href="#%s" id="%s" data-id="%s">' % (id_, id_, id_)
+    return format_html('<a href="#{id}" id="{id}" data-id="{id}">', id=attrs["id"])
 
 
 class AnchorIdentifierLinkHandler(LinkHandler):
@@ -40,9 +38,7 @@ class AnchorIdentifierLinkHandler(LinkHandler):
         if renderer is None:
             renderer = getattr(settings, "DRAFTAIL_ANCHORS_RENDERER", render_a)
             if isinstance(renderer, str):
-                module_path, *attr = renderer.rsplit(".", maxsplit=1)
-                module = importlib.import_module(module_path)
-                renderer = getattr(module, attr[0]) if attr else module
+                renderer = import_string(renderer)
             cls._renderer = renderer
         return renderer
 

--- a/wagtail_draftail_anchors/wagtail_hooks.py
+++ b/wagtail_draftail_anchors/wagtail_hooks.py
@@ -1,16 +1,22 @@
 from django.conf import settings
 
+from wagtail import VERSION as wagtail_version
 import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 from wagtail.admin.rich_text.converters.html_to_contentstate import (
     BlockElementHandler,
     InlineStyleElementHandler,
 )
-from wagtail.core import hooks
+
+if wagtail_version >= (3, 0):
+    from wagtail import hooks
+else:
+    from wagtail.core import hooks
 
 from .rich_text import (
     AnchorBlockConverter,
     AnchorBlockHandler,
     AnchorIndentifierEntityElementHandler,
+    AnchorIdentifierLinkHandler,
     anchor_identifier_entity_decorator,
 )
 
@@ -129,3 +135,5 @@ def register_rich_text_anchor_identifier_feature(features):
             },
         },
     )
+
+    features.register_link_type(AnchorIdentifierLinkHandler)


### PR DESCRIPTION
This pull request adds support for custom rendering of anchors. Prior to these changes, anchors added using the anchor-identifier rich text feature would always be rendered as `a` elements, which is not always desirable.

The changes work as follows:
1. `anchor_identifier_entity_decorator` is updated so that it adds a `linktype` attribute of "anchor-target" to the entity when converting to the DB storage format.
2. a custom link handler (`AnchorIdentifierLinkHandler`) is registered with Wagtail, which will handle all links with a `linktype` of "anchor-identifier"
3. `AnchorIdentifierLinkHandler` will determine how to render the link in templates from the value of the `DRAFTAIL_ANCHORS_RENDERER` setting.

Using a custom `linktype` and link handler in this manner means that the presentation of anchors is decoupled from the DB storage format, allowing users to control the output in template rendering.

The default renderer is consistent with the behaviour of this package prior to these changes.